### PR TITLE
Python Bindings: Basic Particle Interface

### DIFF
--- a/example/test_python_bindings.py
+++ b/example/test_python_bindings.py
@@ -156,18 +156,9 @@ def main() -> None:
         # Generate a random set of hits around the particle position.
         particle_hits = np.stack(
             (
-                [
-                    random.uniform(x - 100, x + 100)
-                    for _ in range(num_hits_per_particle)
-                ],
-                [
-                    random.uniform(y - 100, y + 100)
-                    for _ in range(num_hits_per_particle)
-                ],
-                [
-                    random.uniform(z - 100, z + 100)
-                    for _ in range(num_hits_per_particle)
-                ],
+                [random.uniform(x - 25, x + 25) for _ in range(num_hits_per_particle)],
+                [random.uniform(y - 25, y + 25) for _ in range(num_hits_per_particle)],
+                [random.uniform(z - 25, z + 25) for _ in range(num_hits_per_particle)],
             ),
             axis=1,
         )

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -6,7 +6,7 @@ project(HepEVD LANGUAGES CXX)
 if (NOT SKBUILD)
     message(WARNING "\
         The 'HepEVD' extension requires the 'skbuild' package. \
-        
+
         If you are a user trying to install this package, use the \
         command below, which will install all necessary build dependencies, \
         compile the package in an isolated environment, and then install it. \
@@ -72,10 +72,14 @@ nanobind_add_module(
     src/include/geometry.hpp
     src/include/detectors.hpp
     src/geometry.cpp
-    
+
     # ... Hit related code
     src/include/hits.hpp
     src/hits.cpp
+
+    # ... Particle related code
+    src/include/particles.hpp
+    src/particles.cpp
 
     # ... Marker related code
     src/include/markers.hpp

--- a/python_bindings/README.md
+++ b/python_bindings/README.md
@@ -36,8 +36,3 @@ python
 $ import HepEVD
 ```
 
-## TODO
-
- - Add ability to pass over clusters / particles:
-    - I.e. groups of hits, and hierarchies of groups of hits
-    - Need to work out the best interface for that...

--- a/python_bindings/src/HepEVD.cpp
+++ b/python_bindings/src/HepEVD.cpp
@@ -17,6 +17,7 @@
 #include "include/geometry.hpp"
 #include "include/global.hpp"
 #include "include/hits.hpp"
+#include "include/particles.hpp"
 #include "include/markers.hpp"
 
 namespace nb = nanobind;
@@ -106,6 +107,14 @@ NB_MODULE(_hepevd_impl, m) {
           nb::sig("def add_mc(hits: collections.abc.Collection[collections.abc.Collection[float | int | HitType | "
                   "HitDimension]], "
                   "label: str = '') -> None"));
+    m.def("add_particles", &HepEVD_py::add_particles,
+          "Adds particles to the current event state.\n"
+          "Particles must be passed as an (NParticles, NHits, Y) list or array, with the columns being "
+          "(x, y, z, energy) and two optional columns (view, dimension) for the hit type and dimension.\n"
+          "The view and dimension values must be from the HepEVD.HitType and HepEVD.HitDimension enums respectively.",
+          nb::arg("particles"), nb::arg("label") = "",
+          nb::sig("def add_particles(particles: collections.abc.Collection[collections.abc.Collection[collections.abc.Collection[float | int | "
+                  "HitType | HitDimension]]], label: str = '') -> None"));
     m.def("add_hit_properties", &HepEVD_py::set_hit_properties,
           "Add custom properties to a hit, via a string / double dictionary.\n"
           "The hit must be passed as a (x, y, z, energy) list or array.",

--- a/python_bindings/src/include/particles.hpp
+++ b/python_bindings/src/include/particles.hpp
@@ -1,0 +1,25 @@
+// particles.hpp
+
+#ifndef HEP_EVD_PY_PARTICLES_HPP
+#define HEP_EVD_PY_PARTICLES_HPP
+
+// Standard includes
+#include <string>
+
+// Include nanobind headers
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+namespace HepEVD_py {
+
+/**
+ * Add the given list/array of particles to the server.
+ *
+ * @param particles The handle to the list/array of particles.
+ * @param label The optional label for the particles (default: empty string).
+ */
+void add_particles(nb::handle particles, std::string label = "");
+
+} // namespace HepEVD_py
+
+#endif // HEP_EVD_PY_PARTICLES_HPP

--- a/python_bindings/src/particles.cpp
+++ b/python_bindings/src/particles.cpp
@@ -1,0 +1,115 @@
+//
+// Particle-based functions for the HepEVD Python Bindings
+//
+
+// Standard includes
+#include <iostream>
+#include <map>
+#include <vector>
+
+// Include the HepEVD header files.
+#define HEP_EVD_BASE_HELPER 1
+#include "hep_evd.h"
+
+// Local Includes
+#include "include/array_list_utils.hpp"
+#include "include/global.hpp"
+#include "include/hits.hpp"
+
+// Include nanobind
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+
+namespace nb = nanobind;
+
+namespace HepEVD_py {
+
+void add_particles(nb::handle particles, std::string label) {
+
+    if (!HepEVD::isServerInitialised())
+        return;
+
+    if (!isArrayOrList(particles))
+        throw std::runtime_error("HepEVD: Particles must be an array or list");
+
+    BasicSizeInfo arraySize = getBasicSizeInfo(particles);
+
+    // For now, we only a flat list of particles.
+    // That is:
+    // - A 3D array: (P, H, 4) where P is the number of particles and H is the number of hits per particle.
+    // TODO: Ideally, we want to support any number of levels of nesting, such
+    // that we can have complex parent-child relationships.
+    // For now, we will just assume a flat list of particles.
+    if (arraySize.size() != 3)
+        throw std::runtime_error(
+            "HepEVD: Particles array must be 3D!\n "
+            "Expected shape (P, H, 4) where P is the number of particles and H is the number of hits per particle.\n");
+
+    HepEVD::Particles hepEVDParticles;
+
+    int numParticles = arraySize[0];
+
+    for (int particleIdx = 0; particleIdx < numParticles; particleIdx++) {
+
+        // Get the hits for this particle.
+        BasicSizeInfo particleSize = getBasicSizeInfo(particles[particleIdx]);
+        int numHits = particleSize[0];
+
+        HepEVD::Hits particleHits;
+
+        for (int hitIdx = 0; hitIdx < numHits; hitIdx++) {
+
+            // Get the hit for this particle.
+            nb::handle hitHandle = particles[particleIdx][hitIdx];
+
+            // Check that the hit is a list or array.
+            if (!isArrayOrList(hitHandle))
+                throw std::runtime_error("HepEVD: Hit must be an array or list");
+
+            BasicSizeInfo hitSize = getBasicSizeInfo(hitHandle);
+
+            // Each hit should be a 1D array with 4+ elements...
+            if (hitSize.size() != 1 || hitSize[0] < 4)
+                throw std::runtime_error("HepEVD: Hit must be a 1D array, with at least 4 elements (x, y, z, energy)");
+
+            // Get hit data
+            auto hitData = getItems(hitHandle, 0, hitSize[0]);
+            int dataSize = hitSize[0];
+
+            auto idx(0);
+            double x = hitData[idx++];
+            double y = hitData[idx++];
+            double z = hitData[idx++];
+            double energy = hitData[idx++];
+
+            // Optional view and dimension.
+            bool includesView = dataSize >= 6;
+            double dimension = includesView ? hitData[idx++] : -1.0;
+            double view = includesView ? hitData[idx++] : -1.0;
+
+            HepEVD::Hit *hepHit = new HepEVD::Hit({x, y, z}, energy);
+
+            if (includesView) {
+                hepHit->setHitType(static_cast<HepEVD::HitType>(view));
+                hepHit->setDim(static_cast<HepEVD::HitDimension>(dimension));
+            }
+
+            if (!label.empty())
+                hepHit->setLabel(label);
+
+            particleHits.push_back(hepHit);
+        }
+
+        // Now, we can create a HepEVD particle object.
+        std::string id(HepEVD::getUUID());
+        HepEVD::Particle *hepParticle = new HepEVD::Particle(particleHits, id, label);
+        hepEVDParticles.push_back(hepParticle);
+    }
+
+    // Finally, we can add the particles to the HepEVD server.
+    HepEVD::hepEVDLog("Adding " + std::to_string(hepEVDParticles.size()) + " particles to the HepEVD server.");
+    HepEVD::getServer()->addParticles(hepEVDParticles);
+}
+
+} // namespace HepEVD_py

--- a/web/hep_evd.js
+++ b/web/hep_evd.js
@@ -21,7 +21,7 @@ import {
   setupMobileUI,
   toggleTheme,
 } from "./ui.js";
-import { highlightParticleOnMouseMove } from "./interactions.js";
+import { setupMouseOverInteractions } from "./interactions.js";
 
 // Set off the data loading straight away.
 // For big events, this can take a while, so we want to do it in parallel with
@@ -33,7 +33,7 @@ const threeDCamera = new THREE.PerspectiveCamera(
   50,
   window.innerWidth / window.innerHeight,
   0.1,
-  1e6,
+  1e6
 );
 const twoDCamera = new THREE.OrthographicCamera(
   window.innerWidth / -2,
@@ -41,7 +41,7 @@ const twoDCamera = new THREE.OrthographicCamera(
   window.innerHeight / 2,
   window.innerHeight / -2,
   -1,
-  1e6,
+  1e6
 );
 const renderer = new THREE.WebGLRenderer({
   alpha: true,
@@ -84,7 +84,7 @@ const threeDRenderer = new RenderState(
   mcHits.filter((hit) => hit.position.dim === "3D"),
   markers.filter((marker) => marker.position.dim === "3D"),
   detectorGeometry,
-  stateInfo,
+  stateInfo
 );
 const twoDRenderer = new RenderState(
   "2D",
@@ -95,7 +95,7 @@ const twoDRenderer = new RenderState(
   mcHits.filter((hit) => hit.position.dim === "2D"),
   markers.filter((marker) => marker.position.dim === "2D"),
   detectorGeometry,
-  stateInfo,
+  stateInfo
 );
 threeDRenderer.otherRenderer = twoDRenderer;
 twoDRenderer.otherRenderer = threeDRenderer;
@@ -151,7 +151,7 @@ window.addEventListener(
     onWindowResize(threeDRenderer, renderer);
     onWindowResize(twoDRenderer, renderer);
   },
-  false,
+  false
 );
 document.resetView = () => {
   threeDRenderer.resetView();
@@ -162,13 +162,5 @@ updateStateUI(renderStates);
 
 // Add in interactions...
 if (!config.disableMouseOver) {
-  let currentlyHighlighting = [];
-  const canvas = renderer.domElement;
-  canvas.addEventListener("mousemove", (event) => {
-    currentlyHighlighting = highlightParticleOnMouseMove(
-      renderStates,
-      currentlyHighlighting,
-      event,
-    );
-  });
+  setupMouseOverInteractions(renderer.domElement, renderStates);
 }

--- a/web/interactions.js
+++ b/web/interactions.js
@@ -4,21 +4,46 @@
 
 import * as THREE from "three";
 
+// Mouseover interactions can be very expensive, so we try to
+// limit the number of times we do this by only checking
+// every 16 milliseconds (60 FPS).
+const INTERACTION_CHECK_INTERVAL = 16;
+let mouseTimeout;
+
+// Also store and re-use certain objects to avoid
+// creating new ones every time.
+const mouse = new THREE.Vector2();
+const raycaster = new THREE.Raycaster();
+
+/**
+ * Highlights a particle on mouse move, if applicable.
+ * I.e. if the mouse is over a particle, dull the others and highlight the one under the mouse.
+ *
+ * @param {Map<string, RenderState>} renderStates - The render states to check for highlights.
+ * @param {Array<string>} currentlyHighlighting - The currently highlighted particles.
+ * @param {MouseEvent} event - The mouse event to check for highlights.
+ * @returns {Array<string>} - The IDs of the particles that are currently highlighted.
+ */
 export function highlightParticleOnMouseMove(
   renderStates,
   currentlyHighlighting,
-  event,
+  event
 ) {
+  if (mouseTimeout) return currentlyHighlighting;
+
+  mouseTimeout = setTimeout(() => {
+    mouseTimeout = null;
+  }, INTERACTION_CHECK_INTERVAL);
+
   // This only works if we have a particle data state,
   // since we can't relate unassociated hits.
   if (
     !Array.from(renderStates.values()).some(
-      (state) => state.particleData.length !== 0,
+      (state) => state.particleData.length !== 0
     )
   )
     return [];
 
-  const mouse = new THREE.Vector2();
   mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
   mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
 
@@ -28,7 +53,6 @@ export function highlightParticleOnMouseMove(
   //  - Highlighting a particles parent and all of the parent's children. (Shift)
   const shiftPressed = event.shiftKey;
   const ctrlPressed = event.ctrlKey;
-
   let selectedParticles = [];
 
   renderStates.forEach((state) => {
@@ -36,56 +60,54 @@ export function highlightParticleOnMouseMove(
       return;
     }
 
-    const raycaster = new THREE.Raycaster();
     raycaster.setFromCamera(mouse, state.camera);
-    const intersects = raycaster.intersectObjects(state.scene.children, true);
-    const visibleIntersects = intersects.filter((intersect) => {
-      return intersect.object.material.opacity >= 0.75;
+    const intersects = raycaster.intersectObjects([state.hitGroup], true);
+
+    // Find first valid intersection in one pass
+    const intersectObject = intersects.find((intersect) => {
+      return (
+        intersect.object.type === "Mesh" &&
+        intersect.object.material.opacity >= 0.75
+      );
     });
-    if (visibleIntersects.length > 0) {
-      const intersectObject = visibleIntersects[0];
 
-      if (intersectObject.object.type !== "Mesh") {
-        return;
-      }
+    if (!intersectObject) return;
 
-      const hitNum = intersectObject.instanceId;
-      const activeHit = state.particleData.activelyDrawnHits[hitNum];
-      let activeParticle;
+    const hitNum = intersectObject.instanceId;
+    const activeHit = state.particleData.activelyDrawnHits[hitNum];
+    if (!activeHit) return;
 
-      try {
-        const activeParticleId = state.particleData.hitToParticleMap.get(
-          activeHit.id,
-        );
-        activeParticle = state.particleData.particleMap.get(activeParticleId);
-      } catch {
-        return;
-      }
+    const activeParticleId = state.particleData.hitToParticleMap.get(
+      activeHit.id
+    );
+    if (!activeParticleId) return;
 
-      const parentParticle = state.particleData.getParent(activeParticle);
-      const targetParticle = shiftPressed ? parentParticle : activeParticle;
+    const activeParticle = state.particleData.particleMap.get(activeParticleId);
+    if (!activeParticle) return;
 
-      if (!targetParticle) return;
+    const parentParticle = state.particleData.getParent(activeParticle);
+    const targetParticle = shiftPressed ? parentParticle : activeParticle;
 
-      selectedParticles.push(targetParticle.id);
+    if (!targetParticle) return;
 
-      // If we're already highlighting this particle, don't do anything.
-      if (currentlyHighlighting.includes(targetParticle.id)) {
-        return;
-      } else {
-        state.particleData.disableHighlights();
-      }
+    selectedParticles.push(targetParticle.id);
 
-      // Include the child particles if shift or ctrl is pressed.
-      if (ctrlPressed || shiftPressed) {
-        targetParticle.childIDs.map((childId) => {
-          state.particleData.addHighlightTarget(childId);
-        });
-      }
-
-      state.particleData.addHighlightTarget(targetParticle.id);
-      state.triggerEvent("fullUpdate");
+    // If we're already highlighting this particle, don't do anything.
+    if (currentlyHighlighting.includes(targetParticle.id)) {
+      return;
+    } else {
+      state.particleData.disableHighlights();
     }
+
+    // Include the child particles if shift or ctrl is pressed.
+    if (ctrlPressed || shiftPressed) {
+      targetParticle.childIDs.forEach((childId) => {
+        state.particleData.addHighlightTarget(childId);
+      });
+    }
+
+    state.particleData.addHighlightTarget(targetParticle.id);
+    state.triggerEvent("fullUpdate");
   });
 
   if (currentlyHighlighting.length > 0 && selectedParticles.length === 0) {
@@ -99,4 +121,53 @@ export function highlightParticleOnMouseMove(
   }
 
   return selectedParticles;
+}
+
+/**
+ * Sets up mouse-over interactions with camera movement tracking.
+ * Disables highlighting during camera movement for better performance.
+ *
+ * @param {HTMLCanvasElement} canvas - The renderer canvas element
+ * @param {Map<string, RenderState>} renderStates - The render states
+ */
+export function setupMouseOverInteractions(canvas, renderStates) {
+  let currentlyHighlighting = [];
+  let isMovingCamera = false;
+  let movementTimeout;
+
+  // Track camera movement to disable mouseovers during movement
+  renderStates.forEach((state) => {
+    state.controls.addEventListener("start", () => {
+      isMovingCamera = true;
+      // Clear any existing highlights when starting camera movement
+      if (currentlyHighlighting.length > 0) {
+        renderStates.forEach((renderState) => {
+          if (renderState.visible) {
+            renderState.particleData.disableHighlights();
+            renderState.triggerEvent("fullUpdate");
+          }
+        });
+        currentlyHighlighting = [];
+      }
+    });
+
+    state.controls.addEventListener("end", () => {
+      // Add small delay before re-enabling to avoid flickering
+      clearTimeout(movementTimeout);
+      movementTimeout = setTimeout(() => {
+        isMovingCamera = false;
+      }, 100);
+    });
+  });
+
+  canvas.addEventListener("mousemove", (event) => {
+    // Skip highlighting during camera movement
+    if (isMovingCamera) return;
+
+    currentlyHighlighting = highlightParticleOnMouseMove(
+      renderStates,
+      currentlyHighlighting,
+      event
+    );
+  });
 }

--- a/web/mc_data_state.js
+++ b/web/mc_data_state.js
@@ -20,6 +20,15 @@ export class MCDataState {
   }
 
   /**
+   * Get the number of active MC hits.
+   *
+   * @return {number} The number of active MC hits.
+   */
+  get length() {
+    return this.activeMC.length;
+  }
+
+  /**
    * Top level update function, to update what the active MC hits are.
    *
    * @param {HitTypeState} hitTypeState - The hit type state object.

--- a/web/render_state.js
+++ b/web/render_state.js
@@ -95,7 +95,9 @@ export class RenderState {
    */
   get hitSize() {
     if (this.particleData.length > 0) return this.particleData.length;
-    return this.hitData.length;
+    if (this.hitData.length > 0) return this.hitData.length;
+    if (this.mcData.length > 0) return this.mcData.length;
+    return 0;
   }
 
   /**
@@ -172,6 +174,21 @@ export class RenderState {
 
     // Setup the controls, since it varies depending on the view type.
     this.controlsSetups = false;
+
+    // Before we set things up...is there any non-MC data?
+    // i.e. particles or hits? If not...its easiest to fake
+    // a single hit here, and then render that out.
+    const nothingButMC =
+      filteredParticles.length === 0 && hits.length === 0 && mcHits.length > 0;
+
+    if (nothingButMC) {
+      // If there is zero "real" hits to render, but there are MC hits,
+      // just add a single, fake, empty hit to the hitData.
+      const hit = mcHits[0];
+      hit.position.x += 1e6;
+
+      hits = [hit];
+    }
 
     // These store the actual hits/markers etc that are in use.
     // This can differ from the static arrays above, as we may


### PR DESCRIPTION
Add the ability to pass over particles via the Python interface.

At the moment it is basic, and doesn't have any of the parent child links.

Also took the opportunity to improve the mouseover interactions, as on the giant ND-LAr events, it can be incredibly slow. Disabling interactions whilst moving the scene seems to make everything feel fast enough.